### PR TITLE
fix: remove references to `absurd`

### DIFF
--- a/chapters/aml.typ
+++ b/chapters/aml.typ
@@ -20,7 +20,6 @@ In this section we summarise the syntax and typing rules of #aml (Ambivalent ML)
 #let ewith = textsf("with")
 #let efun = textsf("fun")
 #let etype = textsf("type")
-#let eabsurd = textsf("absurd")
 
 _Expressions_. The syntax of expressions is as follows:
 #syntax(
@@ -28,11 +27,11 @@ _Expressions_. The syntax of expressions is as follows:
     name: [Expressions],
     $e ::= &x | efun x -> e | e space e \
       | &elet x = e ein e | efun (etype alpha) -> e | (e : tau) \
-      | &erefl | eabsurd | ematch (e : tau = tau) ewith erefl -> e$,
+      | &erefl | ematch (e : tau = tau) ewith erefl -> e$,
   ),
 )
 
-#aml extends #ml expressions, variables, functions and let expressions are standard. #aml introduces an explicit universal quantifier $efun (etype alpha) -> e$, equivalent to System #textsf("F")'s $Lambda alpha. e$. The constructor $erefl$ has the type $tau = tau$. The $ematch (e : tau_1 = tau_2) ewith erefl -> e'$ construct introduces the type-level equality in $e'$ as a _local constraint_ using the proof $e$. The $eabsurd$ term is used to refute statically impossible cases, such as a inconsistent local constraint $tint = textsf("string")$.
+#aml extends #ml expressions, variables, functions and let expressions are standard. #aml introduces an explicit universal quantifier $efun (etype alpha) -> e$, equivalent to System #textsf("F")'s $Lambda alpha. e$. The constructor $erefl$ has the type $tau = tau$. The $ematch (e : tau_1 = tau_2) ewith erefl -> e'$ construct introduces the type-level equality in $e'$ as a _local constraint_ using the proof $e$.
 
 #let tformer = textsf("F")
 #let tint = textsf("int")

--- a/chapters/constraints.typ
+++ b/chapters/constraints.typ
@@ -557,7 +557,6 @@ We introduce a function $[| e : alpha |]$, which translates the expression $e$ a
 #let ewith = textsf("with")
 #let efun = textsf("fun")
 #let etype = textsf("type")
-#let eabsurd = textsf("absurd")
 #let tformer = textsf("F")
 
 $
@@ -569,7 +568,6 @@ $
   [| efun (etype beta) -> e : alpha |] &= clet x : paren.l.double e paren.r.double_beta cin x <= alpha \ 
   [| (e : tau) : alpha |] &= alpha supset.eq tau and [| e : tau |] \ 
   [| erefl : alpha |] &= exists alpha_1. alpha supset.eq (alpha_1 = alpha_1) \ 
-  // [| eabsurd : alpha |] &= eabsurd \ 
   [| ematch (e_1 : tau_1 = tau_2) ewith erefl -> e_2 : alpha |] &= [| e_1 : tau_1 = tau_2 |] and (tau_1 = tau_2) ==> [| e_2 : alpha |]
 $
 


### PR DESCRIPTION
We currently don't have a proper treatment for `absurd` (both the constraint and expression)