### PR TITLE
refactor: move common definitions / macros to `cmon.typ`

### DIFF
--- a/chapters/aml.typ
+++ b/chapters/aml.typ
@@ -2,24 +2,12 @@
 #import "../lib/syntax.typ": *
 #import "../lib/thm.typ": *
 #import "@preview/curryst:0.3.0": rule, proof-tree
+#import "cmon.typ": *
 
 // HACK to get thm to left align
 #show: thmrules
 
-#let aml = textsf("AML")
-#let ml = textsf("ML")
-
-
 In this section we summarise the syntax and typing rules of #aml (Ambivalent ML), a conservative extension of the #ml calculus with _ambivalent types_ ($tau approx tau'$) and a type-level equality type ($tau = tau'$).
-
-#let tint = textsf("tint")
-#let erefl = textsf("Refl")
-#let elet = textsf("let")
-#let ein = textsf("in")
-#let ematch = textsf("match")
-#let ewith = textsf("with")
-#let efun = textsf("fun")
-#let etype = textsf("type")
 
 _Expressions_. The syntax of expressions is as follows:
 #syntax(
@@ -32,10 +20,6 @@ _Expressions_. The syntax of expressions is as follows:
 )
 
 #aml extends #ml expressions, variables, functions and let expressions are standard. #aml introduces an explicit universal quantifier $efun (etype alpha) -> e$, equivalent to System #textsf("F")'s $Lambda alpha. e$. The constructor $erefl$ has the type $tau = tau$. The $ematch (e : tau_1 = tau_2) ewith erefl -> e'$ construct introduces the type-level equality in $e'$ as a _local constraint_ using the proof $e$.
-
-#let tformer = textsf("F")
-#let tint = textsf("int")
-#let ok = textsf("ok")
 
 _Types_. The syntax of types is as follows:
 #syntax(
@@ -64,8 +48,6 @@ _Type schemes_ are also affected by the notion of _sharing_. Instead of a normal
 Contexts bind program variables to type schemes, introduce _variable bounds_, and store type equations $tau = tau'$.
 They are ordered and duplicates are disallowed. We write $Gamma, Gamma'$ for the concatenation of two contexts (assuming disjointness holds). 
 
-
-#let fv = textsf("fv")
 
 The definition for the set of free variables on types, shallow types, ambivalent types, and schemes is mostly standard.
 

--- a/chapters/cmon.typ
+++ b/chapters/cmon.typ
@@ -1,0 +1,37 @@
+#import "../lib/syntax.typ": *
+
+// System names
+#let aml = textsf("AML")
+#let ml = textsf("ML")
+
+// Types
+#let tint = textsf("int")
+#let tstring = textsf("string")
+
+#let tformer = textsf("F")
+#let tforall(alpha) = $forall #alpha. space$
+#let tforallb(alpha, bound) = $forall (#alpha >= #bound). space$
+
+// Expressions
+#let erefl = textsf("Refl")
+#let elet = textsf("let")
+#let ein = textsf("in")
+#let ematch = textsf("match")
+#let ewith = textsf("with")
+#let efun = textsf("fun")
+#let etype = textsf("type")
+
+// Constraints
+#let cdef = textsf("def")
+#let cin = textsf("in")
+#let ctrue = textsf("true")
+#let cfalse = textsf("false")
+#let clet = textsf("let")
+#let cis = textsf("is")
+
+// Judgements
+#let ok = textsf("ok")
+
+// Functions
+#let fv = textsf("fv")
+#let arity = textsf("arity")

--- a/chapters/constraints.typ
+++ b/chapters/constraints.typ
@@ -3,20 +3,9 @@
 #import "../lib/syntax.typ": *
 #import "../lib/thm.typ": *
 #import "@preview/curryst:0.3.0": rule, proof-tree
+#import "cmon.typ": *
 
-
-#let aml = textsf("AML")
-#let cdef = textsf("def")
-#let cin = textsf("in")
-#let ctrue = textsf("true")
-#let cfalse = textsf("false")
-#let clet = textsf("let")
-#let cis = textsf("is")
-#let ok = textsf("ok")
 #let consistent = textsf("consistent")
-
-#let var = textsf("Var")
-#let tformer = textsf("F")
 
 #let gt = math.upright(math.bold("t"))
 #let gs = math.upright(math.bold("s"))
@@ -285,8 +274,6 @@ $
   tau ::= alpha | overline(tau) tformer | tau approx tau
 $
 
-#let arity = textsf("arity")
-
 Let $cal(S)$ be a _signature_ for type formers, defining an arity function $arity_cal(S)$ mapping type formers $tformer$ to their arity $n in NN$. A type $tau$ is well-formed in the context of the signature $cal(S)$, written $cal(S) tack tau$, if each occurance of the type former $overline(tau') tformer$ has the correct arity $|overline(tau')| = arity_cal(S)(tformer)$.  
 
 Our algebra is associated with a equational theory $E(equiv)$ defined by the following set of axioms:
@@ -549,15 +536,6 @@ $
 
 We introduce a function $[| e : alpha |]$, which translates the expression $e$ and type variable $alpha$ to a constraint. Assuming $e$ is well-formed under $Delta$ ($Delta tack e ok $), then $[| e : alpha |]$ is well-formed under $Delta$ and $alpha$ ($alpha : circle.small.filled, Delta tack [|e : alpha|] ok$). 
 
-
-#let erefl = textsf("Refl")
-#let elet = textsf("let")
-#let ein = textsf("in")
-#let ematch = textsf("match")
-#let ewith = textsf("with")
-#let efun = textsf("fun")
-#let etype = textsf("type")
-#let tformer = textsf("F")
 
 $
   

--- a/lib/syntax.typ
+++ b/lib/syntax.typ
@@ -1,7 +1,5 @@
 #let textsf = text.with(font: "roboto")
 #let dom = textsf("dom")
-#let tforall(alpha) = $forall #alpha. med$
-#let tforallb(alpha, bound) = $forall (#alpha >= #bound). med$
 
 #let is-content = this => {
   type(this) == str or type(this) == content or type(this) == symbol


### PR DESCRIPTION
Additionally attempt to make `lib/` more portable / independent from AML