### PR TITLE
feat:  scope-based presentation of AML

### DIFF
--- a/chapters/cmon.typ
+++ b/chapters/cmon.typ
@@ -1,18 +1,48 @@
 #import "../lib/syntax.typ": *
 
+#let textsf = text.with(font: "roboto")
+
+#let dom = textsf("dom")
+#let rng = textsf("rng")
+
 // System names
 #let aml = textsf("AML")
 #let ml = textsf("ML")
+#let xaml = textsf("xAML")
+
+// Sets
+#let varset(s) = $cal(V)_(#s)$
+#let disjoint = $op(\#)$ 
+
+#let Ty = textsf("Ty")
+#let TyCon = textsf("TyCon")
+#let Scm = textsf("Scm")
+#let Scope = textsf("Scope")
+#let Ctx = textsf("Ctx")
+#let Exp = textsf("Exp")
+#let Con = textsf("Con")
+#let EqName = textsf("EqName")
+#let Kind = textsf("Kind")
+#let Flex = textsf("Flex")
+
+#let ty = textsf("ty")
+#let scope = textsf("sc")
 
 // Types
+#let eqname = $phi.alt$
 #let tint = textsf("int")
 #let tstring = textsf("string")
-
+#let tunit = textsf("unit")
 #let tformer = textsf("F")
+#let tformerg = textsf("G")
 #let tforall(alpha) = $forall #alpha. space$
-#let tforallb(alpha, bound) = $forall (#alpha >= #bound). space$
+#let scopev = $sigma.alt$
 
-// Expressions
+
+#let fflex = $upright(f)$
+#let frigid = $upright(r)$
+
+// Expressions / terms 
 #let erefl = textsf("Refl")
 #let elet = textsf("let")
 #let ein = textsf("in")
@@ -32,6 +62,13 @@
 
 // Judgements
 #let ok = textsf("ok")
+#let ctx = textsf("ctx")
+#let scm = textsf("scm")
+#let rigid = textsf("rigid")
+
+#let dangerous = $textsf("dangerous")$
+
+#let sdtack = $scripts(tack)_textsf("SD")$
 
 // Functions
 #let fv = textsf("fv")

--- a/chapters/proofs/aml.typ
+++ b/chapters/proofs/aml.typ
@@ -1,0 +1,10 @@
+#import "../../lib/std.typ": *
+#import "../..//lib/syntax.typ": *
+#import "../../lib/thm.typ": *
+#import "@preview/curryst:0.3.0": rule, proof-tree
+#import "../cmon.typ": *
+
+// HACK to get thm to left align
+#show: thmrules
+
+#comment[TODO]

--- a/lib/template.typ
+++ b/lib/template.typ
@@ -86,3 +86,9 @@
 
   body
 }
+
+#let appendix(body) = {
+  set heading(numbering: "A", supplement: [Appendix])
+  counter(heading).update(0)
+  body
+}

--- a/lib/thm.typ
+++ b/lib/thm.typ
@@ -8,6 +8,14 @@
     #body
   ],
 )
+#let lemma = thmbox(
+  "lemma", 
+  "Lemma", 
+  bodyfmt: body => [
+    #set align(left)
+    #body
+  ],
+)
 #let corollary = thmplain(
   "corollary",
   "Corollary",

--- a/main.typ
+++ b/main.typ
@@ -1,7 +1,7 @@
 #import "lib/template.typ": *
 
 #show: cam-notes.with(
-  title: [ Constraint-Based Type Inference for GADTs ],
+  title: [ Principal and Easy Constraint-Based Type Inference for GADTs ],
 
   subtitle: [ Technical Report ],
 
@@ -13,7 +13,7 @@
     .display("[month repr:long] [day padding:none], [year repr:full]"),
 )
 
-= AML 
+= AML <aml>
 
 #include "chapters/aml.typ"
 #pagebreak()
@@ -27,3 +27,9 @@
 = Solver
 
 #include "chapters/solver.typ"
+#pagebreak()
+
+#show: appendix
+
+= Proofs for @aml-meta[]
+#include "chapters/proofs/aml.typ"


### PR DESCRIPTION
This PR modifies our current presentation of AML to use scopes instead of ambivalent types. 

Why?

1. We believe scopes may be closer to how our constraint semantics work
2. The presentation is more in the spirit of the standard ML typing rules

