### PR TITLE
fix(solver): unshare scope rows when updating

### DIFF
--- a/examples/bad.ml
+++ b/examples/bad.ml
@@ -1,0 +1,19 @@
+external choose3 : 'a. 'a -> 'a -> 'a -> 'a;;
+
+let f = forall (type 'a 'b 'c 'd) ->
+  fun w1 w2 x1 x2 x3 -> 
+    let x1 = (x1 : 'c) in 
+    let x2 = (x2 : 'd -> 'a) in 
+    let x3 = (x3 : 'd -> 'b) in 
+    match w2 : 'c = ('d -> 'a) with Refl -> 
+    let g = fun z -> 
+      match w1 : 'a = 'b with Refl ->
+      (* The application of [z] here causes the 
+         scope escape. This is because we propagate 
+         the scope variable associated with 'a = 'b 
+         to the LHS of the arrow as well. *)
+      let x4 = choose3 x1 x2 x3 z in
+      ()
+    in 
+    ()
+;;

--- a/examples/icfp.ml
+++ b/examples/icfp.ml
@@ -1,0 +1,18 @@
+external choose3 : 'a. 'a -> 'a -> 'a -> 'a;;
+
+let f = forall (type 'a 'b 'c 'd) ->
+  fun w1 w2 x1 x2 x3 -> 
+    let x1 = (x1 : 'c) in 
+    let x2 = (x2 : 'd -> 'a) in 
+    let x3 = (x3 : 'd -> 'b) in 
+    match w2 : 'c = ('d -> 'a) with Refl -> 
+    (* Under this constraint, 
+       'c is equal to 'd -> 'a *)
+    let g = fun z -> 
+      match w1 : 'a = 'b with Refl ->
+      (* And w1 gives us 'a = 'b, so 
+         x2 and x3 can have the same type. *)
+      (choose3 x1 x2 x3 z : 'a)
+    in 
+    ()
+;;

--- a/lib/constraint_solver/structure.ml
+++ b/lib/constraint_solver/structure.ml
@@ -255,8 +255,12 @@ struct
     in
     (* [impose_scopes ~scope_row as rts] imposes the structure [[scope_row]rt_i] on 
        every variable [a_i]. *)
-    let impose_scopes ~scope_row as' rts =
-      match List.iter2 as' rts ~f:(fun a rt -> a =~- Box (scope_row, rt)) with
+    let impose_scopes ~scope_set as' rts =
+      match
+        List.iter2 as' rts ~f:(fun a rt ->
+          let scope_row = create (Scope (Scope_row.open_ scope_set)) in
+          a =~- Box (scope_row, rt))
+      with
       | Ok () -> ()
       | Unequal_lengths -> assert false
     in
@@ -281,7 +285,7 @@ struct
         scr =~- Scope (Scope_row.open_ scopes);
         (* Every child [a_i] of the structure [s] must be a scoped 
            ambivalent type of the form [[scr]rt_i] *)
-        impose_scopes ~scope_row:scr as' rts);
+        impose_scopes ~scope_set:scopes as' rts);
       (* We favour [Structure] over [Box] because [Structure] is more 
          intuitive for programmers. *)
       Structure s
@@ -313,11 +317,10 @@ struct
           Head { head = hs1; arity = List.length as1 }
           ==? Head { head = hs2; arity = List.length as2 }
         in
-        let scr = create (Scope (Scope_row.open_ scopes)) in
         (* Every child of [s1] (and [s2] resp.) must be a scoped ambivalent 
            type of the form [[scr]rt1_i] ([[scr]rt2_i] resp.) *)
-        impose_scopes ~scope_row:scr as1 rts1;
-        impose_scopes ~scope_row:scr as2 rts2;
+        impose_scopes ~scope_set:scopes as1 rts1;
+        impose_scopes ~scope_set:scopes as2 rts2;
         (* Pick arbitrary structure, could alternatively be [t2] *)
         t1)
     | Scope _, (Structure _ | Box _) | (Structure _ | Box _), Scope _ ->


### PR DESCRIPTION
# Context

At ICFP, @garrigue discovered a bug in AML in which the scope row was incorrectly shared
between children when propagating. This a bug in both the specification *and* the implementation [^1]. 
The program that exhibits this is:
```ocaml 
external choose3 : 'a. 'a -> 'a -> 'a -> 'a;;

let f = forall (type 'a 'b 'c 'd) ->
  fun w1 w2 x1 x2 x3 -> 
    let x1 = (x1 : 'c) in 
    let x2 = (x2 : 'd -> 'a) in 
    let x3 = (x3 : 'd -> 'b) in 
    match w2 : 'c = ('d -> 'a) with Refl -> 
    let g = fun z -> 
      match w1 : 'a = 'b with Refl ->
      (* The application of [z] here causes the 
         scope escape. This is because we propagate 
         the scope variable associated with 'a = 'b 
         to the LHS of the arrow as well. *)
      let x4 = choose3 x1 x2 x3 z in
      ()
    in 
    ()
;;
```

Here, `z` has the type `['c = 'd -> 'a, 'a = 'b]'d`. However, the `'a = 'b` is redundant and is introduced by a unification on the RHS of the arrow when applying `choose3 x1 x2` to `x3` which unifies `'a` with `'b`, introducing the `'a = 'b` equation to the scope. 

# Description

This PR (rather hackily) removes this sharing of scope rows during unification, fixing the bug :) 

[^1]: Something I'm rather proud of 😅 